### PR TITLE
pinentry.el: add simple minibuffer prompt option

### DIFF
--- a/pinentry.el
+++ b/pinentry.el
@@ -57,6 +57,8 @@
 (put 'pinentry-read-point 'permanent-local t)
 (defvar pinentry--read-point nil)
 (put 'pinentry--read-point 'permanent-local t)
+(defvar pinentry--simple-prompt nil
+  "If non-nil enables a simpler PIN prompt 'Enter passphrase:'")
 
 ;; We use the same location as `server-socket-dir', when local sockets
 ;; are supported.
@@ -252,9 +254,11 @@ Assuan protocol."
 		   (process-send-string process "OK\n")))
                 ("GETPIN"
                  (let ((prompt
-                        (or (cdr (assq 'desc pinentry--labels))
-                            (cdr (assq 'prompt pinentry--labels))
-                            ""))
+			(if (bound-and-true-p pinentry--simple-prompt)
+			    "Enter passphrase: "
+			    (or (cdr (assq 'desc pinentry--labels))
+				(cdr (assq 'prompt pinentry--labels))
+				"")))
 		       (confirm (not (null (assq 'repeat pinentry--labels))))
                        entry)
                    (if (setq entry (assq 'error pinentry--labels))


### PR DESCRIPTION
The minibuffer prompts ugly multilines received from gpg-agent
like the following which are especially annoying if there is only
one key used, in which case all this information is also useless.

Please enter the passphrase for the ssh key
  ea:xx:8d:xx:9a:f2:60:xx:xx:xx:62:ac:3d:xx:xx:xx
  (): ............

This change makes the prompt a cleaner "Enter passphrase: " when
a variable is defined like (setq pinentry--simple-prompt t)

Signed-off-by: Ioan-Adrian Ratiu adi@adirat.com
