### PR TITLE
Update from last version in GNU Emacs repository, fix some warnings

### DIFF
--- a/pinentry.el
+++ b/pinentry.el
@@ -19,7 +19,7 @@
 ;; GNU General Public License for more details.
 
 ;; You should have received a copy of the GNU General Public License
-;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+;; along with GNU Emacs.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/pinentry.el
+++ b/pinentry.el
@@ -49,8 +49,6 @@
 
 ;;; Code:
 
-(eval-when-compile (require 'cl-lib))
-
 (defgroup pinentry nil
   "The Pinentry server"
   :version "25.1"
@@ -92,7 +90,7 @@ If local sockets are not supported, this is nil.")
 
 ;; These error codes are defined in libgpg-error/src/err-codes.h.in.
 (defmacro pinentry--error-code (code)
-  (logior (lsh 5 24) code))
+  (logior (ash 5 24) code))
 (defconst pinentry--error-not-implemented
   (cons (pinentry--error-code 69) "not implemented"))
 (defconst pinentry--error-cancelled
@@ -174,7 +172,7 @@ will not be shown."
       (ignore-errors
         (let (delete-by-moving-to-trash)
           (delete-file server-file)))
-      (cl-letf (((default-file-modes) ?\700))
+      (with-file-modes ?\700
         (setq pinentry--server-process
               (make-network-process
                :name "pinentry"


### PR DESCRIPTION
This includes one trivial change in the license notice from the GNU Emacs repository.

Plus, it includes a patch taken from the `app-emacs/pinentry` package in Gentoo Linux that fixes two byte-compile warnings with newer Emacs versions:
https://github.com/gentoo/gentoo/blob/ecafd0276eb5d7c0b5f267136164a6f4e8cb4e09/app-emacs/pinentry/files/pinentry-emacs-29.patch

Also, would it be possible to make a new release for GNU ELPA? The package is still useful with `gpgsm` (which doesn't support loopback), as discussed in https://debbugs.gnu.org/67012.
