### PR TITLE
Add a project URL to the metadata

### DIFF
--- a/pinentry.el
+++ b/pinentry.el
@@ -5,6 +5,7 @@
 ;; Author: Daiki Ueno <ueno@gnu.org>
 ;; Version: 0.1
 ;; Keywords: GnuPG
+;; URL: https://github.com/ueno/pinentry-el
 
 ;; This file is part of GNU Emacs.
 


### PR DESCRIPTION
It took me a while to find the upstream source for this package now that it has been removed form Emacs itself.