### PR TITLE
Handle 'quit' at the pinentry prompt

### DIFF
--- a/pinentry.el
+++ b/pinentry.el
@@ -351,12 +351,18 @@ Assuan protocol."
 				 (pinentry--send-data
 				  process encoded-passphrase)
 				 (process-send-string process "OK\n")))
+                         ((quit user-error)
+                          (message (error-message-string err))
+                          (ignore-errors
+                            (pinentry--send-error
+                             process
+                             pinentry--error-cancelled)))
                          (error
                           (message "GETPIN error %S" err)
-			    (ignore-errors
-			      (pinentry--send-error
-			       process
-			       pinentry--error-cancelled))))
+                          (ignore-errors
+                            (pinentry--send-error
+                             process
+                             pinentry--error-cancelled))))
                        (if passphrase
                            (clear-string passphrase))
                        (if escaped-passphrase


### PR DESCRIPTION
Otherwise, we'll leave the client hanging (and quit from inside a process filter which isn't great). I've also changed the output of "user errors" in general to more closely match the rest of Emacs.